### PR TITLE
Allow running pytest from local host

### DIFF
--- a/{{cookiecutter.project_slug}}/backend/app/.env
+++ b/{{cookiecutter.project_slug}}/backend/app/.env
@@ -1,0 +1,27 @@
+# Allow local pytest-ing
+SERVER_NAME=localhost
+SERVER_HOST=localhost
+
+POSTGRES_SERVER=localhost
+
+# from env-postgres
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD={{cookiecutter.postgres_password}}
+POSTGRES_DB=app
+
+# from env-backend
+BACKEND_CORS_ORIGINS={{cookiecutter.backend_cors_origins}}
+PROJECT_NAME={{cookiecutter.project_name}}
+SECRET_KEY={{cookiecutter.secret_key}}
+FIRST_SUPERUSER={{cookiecutter.first_superuser}}
+FIRST_SUPERUSER_PASSWORD={{cookiecutter.first_superuser_password}}
+SMTP_TLS=True
+SMTP_PORT={{cookiecutter.smtp_port}}
+SMTP_HOST={{cookiecutter.smtp_host}}
+SMTP_USER={{cookiecutter.smtp_user}}
+SMTP_PASSWORD={{cookiecutter.smtp_password}}
+EMAILS_FROM_EMAIL={{cookiecutter.smtp_emails_from_email}}
+
+USERS_OPEN_REGISTRATION=False
+
+SENTRY_DSN={{cookiecutter.sentry_dsn}}

--- a/{{cookiecutter.project_slug}}/docker-compose.dev.ports.yml
+++ b/{{cookiecutter.project_slug}}/docker-compose.dev.ports.yml
@@ -1,5 +1,8 @@
 version: '3.3'
 services:
+  db:
+    ports:
+      - '5432:5432'
   pgadmin:
     ports:
       - '5050:5050'


### PR DESCRIPTION
Running tests should be lightning fast. I was (maybe un-rightely) using the script from `scripts/tests-local.sh`, which takes care of building fresh containers, starting them and then running the tests.

I will keep this process for automatic tests (probably on git hooks)...
This PR provides a way to run pytest locally during base development

Therefore

```
$ cookiecutter full-stack-fastapi-postgresql/ --no-input
$ cd base-project
$ docker-compose up -d
$ cd backend/app/
$ pipenv install --dev
...
$ pipenv shell
$ pytest
```

and tada ! 🎉 

```
================================= test session starts ==================================
platform darwin -- Python 3.7.3, pytest-4.3.0, py-1.7.0, pluggy-0.8.1
rootdir: /Users/emb/git-repos/github/base-project/backend/app, inifile:
plugins: celery-4.2.1
collected 17 items

app/tests/api/api_v1/test_celery.py .                                            [  5%]
app/tests/api/api_v1/test_token.py ..                                            [ 17%]
app/tests/api/api_v1/test_user.py ......                                         [ 52%]
app/tests/crud/test_user.py ........                                             [100%]

============================== 17 passed in 6.16 seconds ===============================
```

There is however this new .env file that the users should be aware of... but that definitevely worth the price IMHO 👶 