### PR TITLE
Update build.sh

### DIFF
--- a/{{cookiecutter.project_slug}}/scripts/build.sh
+++ b/{{cookiecutter.project_slug}}/scripts/build.sh
@@ -3,6 +3,11 @@
 # Exit in case of error
 set -e
 
+if [ -z ${TAG} ]; then
+    echo "Variable TAG must be provided"
+    exit 1
+fi
+
 TAG=${TAG} \
 FRONTEND_ENV=${FRONTEND_ENV-production} \
 docker-compose \


### PR DESCRIPTION
Without this change, if you don't start the call to the script with `TAG=<tag>` you don't get any error description; it just errors after saying `Building backend`.

It looks like this was supposed to be addressed in `docker-compose.deploy.images.yml` by this line:
```
image: '${DOCKER_IMAGE_BACKEND}:${TAG-latest}'
```
The problem is that the `TAG=${TAG}` in this modified file actually sets the variable to "", so the line in the composed dockerfile becomes `image: 'backend:'`, which apparently causes an error without any description.

An alternative solution might be to replace `TAG=${TAG}` in this file with `TAG=${TAG-latest}`; I'm not sure which you'd prefer.