### PR TITLE
Fix models to support pydantic orm_mode

### DIFF
--- a/{{cookiecutter.project_slug}}/backend/app/app/models/item.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/models/item.py
@@ -6,6 +6,9 @@ class ItemBase(BaseModel):
     title: str = None
     description: str = None
 
+    class Config:
+        orm_mode = True
+
 
 # Properties to receive on item creation
 class ItemCreate(ItemBase):

--- a/{{cookiecutter.project_slug}}/backend/app/app/models/user.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/models/user.py
@@ -10,6 +10,8 @@ class UserBase(BaseModel):
     is_superuser: Optional[bool] = False
     full_name: Optional[str] = None
 
+    class Config:
+        orm_mode = True
 
 class UserBaseInDB(UserBase):
     id: int = None


### PR DESCRIPTION
Null (None) values will cause ValidationErrors when used with postgres. 
See: https://github.com/tiangolo/fastapi/issues/361#issuecomment-509764272

I made these changes and it works like a charm. (The issue out-of-the-box being the None value for first superuser's Full Name)

FastAPI version: 0.33.0
Pydantic version: 0.30

Example validation error
```python
INFO: ('192.168.0.2', 53732) - "POST /api/v1/login/test-token HTTP/1.1" 500
ERROR: Exception in ASGI application
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/uvicorn/protocols/http/httptools_impl.py", line 368, in run_asgi
    result = await app(self.scope, self.receive, self.send)
  File "/usr/local/lib/python3.7/site-packages/starlette/applications.py", line 133, in __call__
    await self.error_middleware(scope, receive, send)
  File "/usr/local/lib/python3.7/site-packages/starlette/middleware/errors.py", line 122, in __call__
    raise exc from None
  File "/usr/local/lib/python3.7/site-packages/starlette/middleware/errors.py", line 100, in __call__
    await self.app(scope, receive, _send)
  File "/usr/local/lib/python3.7/site-packages/starlette/middleware/base.py", line 25, in __call__
    response = await self.dispatch_func(request, self.call_next)
  File "./app/main.py", line 34, in db_session_middleware
    response = await call_next(request)
  File "/usr/local/lib/python3.7/site-packages/starlette/middleware/base.py", line 45, in call_next
    task.result()
  File "/usr/local/lib/python3.7/site-packages/starlette/middleware/base.py", line 38, in coro
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.7/site-packages/starlette/middleware/cors.py", line 84, in __call__
    await self.simple_response(scope, receive, send, request_headers=headers)
  File "/usr/local/lib/python3.7/site-packages/starlette/middleware/cors.py", line 140, in simple_response
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.7/site-packages/starlette/exceptions.py", line 73, in __call__
    raise exc from None
  File "/usr/local/lib/python3.7/site-packages/starlette/exceptions.py", line 62, in __call__
    await self.app(scope, receive, sender)
  File "/usr/local/lib/python3.7/site-packages/starlette/routing.py", line 585, in __call__
    await route(scope, receive, send)
  File "/usr/local/lib/python3.7/site-packages/starlette/routing.py", line 207, in __call__
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.7/site-packages/starlette/routing.py", line 40, in app
    response = await func(request)
  File "/usr/local/lib/python3.7/site-packages/fastapi/routing.py", line 122, in app
    skip_defaults=response_model_skip_defaults,
  File "/usr/local/lib/python3.7/site-packages/fastapi/routing.py", line 54, in serialize_response
    raise ValidationError(errors)
pydantic.error_wrappers.ValidationError: 1 validation error
response
  value is not a valid dict (type=type_error.dict)
```