### PR TITLE
Fix typo in `read_item` GET view

### DIFF
--- a/{{cookiecutter.project_slug}}/backend/app/app/api/api_v1/endpoints/items.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/api/api_v1/endpoints/items.py
@@ -66,7 +66,7 @@ def update_item(
 
 
 @router.get("/{id}", response_model=Item)
-def read_user_me(
+def read_item(
     *,
     db: Session = Depends(get_db),
     id: int,
@@ -77,7 +77,7 @@ def read_user_me(
     """
     item = crud.item.get(db_session=db, id=id)
     if not item:
-        raise HTTPException(status_code=400, detail="Item not found")
+        raise HTTPException(status_code=404, detail="Item not found")
     if not crud.user.is_superuser(current_user) and (item.owner_id != current_user.id):
         raise HTTPException(status_code=400, detail="Not enough permissions")
     return item


### PR DESCRIPTION
Swapped `read_user_me` for `read_item` for the single item get request. Looks like it was copied from the user paths and not updated. Doesn't change functionality but is more readable as it didn't make sense to have it called `read_user_me` and might be confusing. While I was at it I also updated the status code for not found to 404, so it's a more helpful error message if not found.