### PR TITLE
Using Pydantic orm_mode to avoid validation error issue

### DIFF
--- a/{{cookiecutter.project_slug}}/backend/app/app/models/item.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/models/item.py
@@ -6,6 +6,11 @@ class ItemBase(BaseModel):
     title: str = None
     description: str = None
 
+    # using Pydantic orm_mode
+    # https://fastapi.tiangolo.com/tutorial/sql-databases/#use-pydantics-orm_mode
+    class Config:
+        orm_mode = True
+
 
 # Properties to receive on item creation
 class ItemCreate(ItemBase):

--- a/{{cookiecutter.project_slug}}/backend/app/app/models/user.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/models/user.py
@@ -10,6 +10,11 @@ class UserBase(BaseModel):
     is_superuser: Optional[bool] = False
     full_name: Optional[str] = None
 
+    # using Pydantic orm_mode
+    # https://fastapi.tiangolo.com/tutorial/sql-databases/#use-pydantics-orm_mode
+    class Config:
+        orm_mode = True
+
 
 class UserBaseInDB(UserBase):
     id: int = None


### PR DESCRIPTION
Hi,
recently I have used this project creator and I have ended up with Validation error on testing either user or item model. 
I have found this issue:
https://github.com/tiangolo/fastapi/issues/413
where the solution is to use `orm_mode = True` at model level.
I have been thinking that it might be good to have it included in the project creator by default so people will avoid this issue.
Best regards,
Radek