### PR TITLE
Simplify DB base class declaration

### DIFF
--- a/{{cookiecutter.project_slug}}/backend/app/app/db/base_class.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/db/base_class.py
@@ -2,9 +2,8 @@ from sqlalchemy.ext.declarative import as_declarative, declared_attr
 
 
 @as_declarative()
-class Base(object):
+class Base:
     # Generate __tablename__ automatically
     @declared_attr
     def __tablename__(cls):
         return cls.__name__.lower()
-

--- a/{{cookiecutter.project_slug}}/backend/app/app/db/base_class.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/db/base_class.py
@@ -1,11 +1,10 @@
-from sqlalchemy.ext.declarative import declarative_base, declared_attr
+from sqlalchemy.ext.declarative import as_declarative, declared_attr
 
 
-class CustomBase(object):
+@as_declarative()
+class Base(object):
     # Generate __tablename__ automatically
     @declared_attr
     def __tablename__(cls):
         return cls.__name__.lower()
 
-
-Base = declarative_base(cls=CustomBase)


### PR DESCRIPTION
Minor fix to simplify the code in DB base class declaration, by making use of the @as_declarative decorator introduced in SQLAlchemy 0.8.3.