### PR TITLE
Hook to hide credentials in gitignore

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -2,7 +2,7 @@ import sys
 from pathlib import Path
 
 
-files_to_ignore = '''
+files_to_ignore_text = '''
 # Warning! Files in the below section contain your credentials!
 # Credentials should never be pushed to the repository.
 cookiecutter-config-file.yml
@@ -14,7 +14,7 @@ if not gitignore.exists():
     # We should assume this file exists otherwise something went wrong
     sys.exit(1)
 
-existing_gitignore = gitignore.read_text()
-gitignore.write_text(existing_gitignore + files_to_ignore)
+existing_gitignore_text = gitignore.read_text()
+gitignore.write_text(existing_gitignore_text + files_to_ignore_text)
 
 sys.exit(0)

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+
+
+files_to_ignore = '''
+# Warning! Files in the below section contain your credentials!
+# Credentials should never be pushed to the repository.
+cookiecutter-config-file.yml
+*.env
+'''
+
+gitignore = Path("./.gitignore")
+if not gitignore.exists():
+    # We should assume this file exists otherwise something went wrong
+    sys.exit(1)
+
+existing_gitignore = gitignore.read_text()
+gitignore.write_text(existing_gitignore + files_to_ignore)
+
+sys.exit(0)


### PR DESCRIPTION
This PR should solve [this issue](https://github.com/tiangolo/full-stack-fastapi-postgresql/issues/122).

We create cookiecutter post-generate [hook](https://cookiecutter.readthedocs.io/en/1.7.0/advanced/hooks.html) that simply adds files with credentials to `.gitignore`

Tested using my fork branch:
`cookiecutter https://github.com/alexmitelman/full-stack-fastapi-postgresql.git`