### PR TITLE
Make the public Traefik network a fixed default

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,6 @@ The input variables, with their default values (some auto generated) are:
  
 * `traefik_constraint_tag`: The tag to be used by the internal Traefik load balancer (for example, to divide requests between backend and frontend) for production. Used to separate this stack from any other stack you might have. This should identify each stack in each environment (production, staging, etc).
 * `traefik_constraint_tag_staging`: The Traefik tag to be used while on staging. 
-* `traefik_public_network`: This assumes you have another separate publicly facing Traefik at the server / cluster level. This is the network that main Traefik lives in.
 * `traefik_public_constraint_tag`: The tag that should be used by stack services that should communicate with the public.
 
 * `flower_auth`: Basic HTTP authentication for flower, in the form`user:password`. By default: "`root:changethis`".

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -23,7 +23,6 @@
 
     "traefik_constraint_tag": "{{cookiecutter.domain_main}}",
     "traefik_constraint_tag_staging": "{{cookiecutter.domain_staging}}",
-    "traefik_public_network": "traefik-public",
     "traefik_public_constraint_tag": "traefik-public",
 
     "flower_auth": "admin:{{cookiecutter.first_superuser_password}}",

--- a/{{cookiecutter.project_slug}}/.env
+++ b/{{cookiecutter.project_slug}}/.env
@@ -6,8 +6,8 @@ DOMAIN=localhost
 # DOMAIN=localhost.tiangolo.com
 # DOMAIN=dev.{{cookiecutter.domain_main}}
 
+TRAEFIK_PUBLIC_NETWORK=traefik-public
 TRAEFIK_TAG={{cookiecutter.traefik_constraint_tag}}
-TRAEFIK_PUBLIC_NETWORK={{cookiecutter.traefik_public_network}}
 TRAEFIK_PUBLIC_TAG={{cookiecutter.traefik_public_constraint_tag}}
 
 DOCKER_IMAGE_BACKEND={{cookiecutter.docker_image_backend}}

--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -394,6 +394,24 @@ And you can use CI (continuous integration) systems to do it automatically.
 
 But you have to configure a couple things first.
 
+### Traefik network
+
+This stack expects the public Traefik network to be named `traefik-public`, just as in the tutorial in <a href="https://dockerswarm.rocks" class="external-link" target="_blank">DockerSwarm.rocks</a>.
+
+If you need to use a different Traefik public network name, update it in the `docker-compose.yml` files, in the section:
+
+```YAML
+networks:
+  traefik-public:
+    external: true
+```
+
+Change `traefik-public` to the name of the used Traefik network. And then update it in the file `.env`:
+
+```bash
+TRAEFIK_PUBLIC_NETWORK=traefik-public
+```
+
 ### Persisting Docker named volumes
 
 You need to make sure that each service (Docker container) that uses a volume is always deployed to the same Docker "node" in the cluster, that way it will preserve the data. Otherwise, it could be deployed to a different node each time, and each time the volume would be created in that new node before starting the service. As a result, it would look like your service was starting from scratch every time, losing all the previous data.
@@ -401,7 +419,6 @@ You need to make sure that each service (Docker container) that uses a volume is
 That's specially important for a service running a database. But the same problem would apply if you were saving files in your main backend service (for example, if those files were uploaded by your users, or if they were created by your system).
 
 To solve that, you can put constraints in the services that use one or more data volumes (like databases) to make them be deployed to a Docker node with a specific label. And of course, you need to have that label assigned to one (only one) of your nodes.
-
 
 #### Adding services with volumes
 

--- a/{{cookiecutter.project_slug}}/cookiecutter-config-file.yml
+++ b/{{cookiecutter.project_slug}}/cookiecutter-config-file.yml
@@ -19,7 +19,6 @@ default_context:
   pgadmin_default_user_password: '{{ cookiecutter.pgadmin_default_user_password }}'
   traefik_constraint_tag: '{{ cookiecutter.traefik_constraint_tag }}'
   traefik_constraint_tag_staging: '{{ cookiecutter.traefik_constraint_tag_staging }}'
-  traefik_public_network: '{{ cookiecutter.traefik_public_network }}'
   traefik_public_constraint_tag: '{{ cookiecutter.traefik_public_constraint_tag }}'
   flower_auth: '{{ cookiecutter.flower_auth }}'
   sentry_dsn: '{{ cookiecutter.sentry_dsn }}'

--- a/{{cookiecutter.project_slug}}/docker-compose.deploy.networks.yml
+++ b/{{cookiecutter.project_slug}}/docker-compose.deploy.networks.yml
@@ -14,5 +14,5 @@ services:
       - default
 
 networks:
-  {{cookiecutter.traefik_public_network}}:
+  traefik-public:
     external: true


### PR DESCRIPTION
:pushpin: Make the public Traefik network a fixed default to simplify development of the project itself.

It's still configurable after generating a project, but this will allow using the same Docker Compose files during development without re-generating a project every time.