### PR TITLE
issue#171 decoded jwt token returns 'email' which is not present

### DIFF
--- a/{{cookiecutter.project_slug}}/backend/app/app/utils.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/utils.py
@@ -101,6 +101,6 @@ def generate_password_reset_token(email: str) -> str:
 def verify_password_reset_token(token: str) -> Optional[str]:
     try:
         decoded_token = jwt.decode(token, settings.SECRET_KEY, algorithms=["HS256"])
-        return decoded_token["email"]
+        return decoded_token["sub"]
     except jwt.JWTError:
         return None


### PR DESCRIPTION
now returned 'sub'. probably caused by 6fdba196397d9896bce0fee80bbb15c479d40e45