### PR TITLE
extending doc to turn off migrations Closes #178

### DIFF
--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -259,10 +259,12 @@ $ alembic revision --autogenerate -m "Add column last_name to User model"
 $ alembic upgrade head
 ```
 
-If you don't want to use migrations at all, uncomment the line in the file at `./backend/app/app/db/init_db.py` with:
+If you don't want to use migrations at all, uncomment the following lines in the file at `./backend/app/app/db/init_db.py`:
 
 ```python
-Base.metadata.create_all(bind=engine)
+from app.db.session import engine
+
+base.Base.metadata.create_all(bind=engine)
 ```
 
 and comment the line in the file `prestart.sh` that contains:

--- a/{{cookiecutter.project_slug}}/backend/app/app/db/init_db.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/db/init_db.py
@@ -3,6 +3,7 @@ from sqlalchemy.orm import Session
 from app import crud, schemas
 from app.core.config import settings
 from app.db import base  # noqa: F401
+# from app.db.session import engine
 
 # make sure all SQL Alchemy models are imported (app.db.base) before initializing DB
 # otherwise, SQL Alchemy might fail to initialize relationships properly
@@ -13,7 +14,7 @@ def init_db(db: Session) -> None:
     # Tables should be created with Alembic migrations
     # But if you don't want to use migrations, create
     # the tables un-commenting the next line
-    # Base.metadata.create_all(bind=engine)
+    # base.Base.metadata.create_all(bind=engine)
 
     user = crud.user.get_by_email(db, email=settings.FIRST_SUPERUSER)
     if not user:


### PR DESCRIPTION
The commented line requires reference to a previously refactored base.py and an additional import to refer to the database engine.

The Readme documents that alembic migration can be turned off and hence this extension of the documentation and commented code allows to do so going forward.

:dancers: When working together in a repo, do consider to use migrations to avoid database schema conflicts that cannot be rolled back.
