### PR TITLE
Make UserInDBBase require id

### DIFF
--- a/{{cookiecutter.project_slug}}/backend/app/app/schemas/user.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/schemas/user.py
@@ -23,7 +23,7 @@ class UserUpdate(UserBase):
 
 
 class UserInDBBase(UserBase):
-    id: Optional[int] = None
+    id: int
 
     class Config:
         orm_mode = True


### PR DESCRIPTION
Since this is the primary key for the user table in the db, it should be safe to make this a required item here (like in schema/items.py).