### PR TITLE
db.refresh() is unnecessary after commits

### DIFF
--- a/{{cookiecutter.project_slug}}/backend/app/app/crud/base.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/crud/base.py
@@ -36,7 +36,6 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType]):
         db_obj = self.model(**obj_in_data)  # type: ignore
         db.add(db_obj)
         db.commit()
-        db.refresh(db_obj)
         return db_obj
 
     def update(
@@ -56,7 +55,6 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType]):
                 setattr(db_obj, field, update_data[field])
         db.add(db_obj)
         db.commit()
-        db.refresh(db_obj)
         return db_obj
 
     def remove(self, db: Session, *, id: int) -> ModelType:

--- a/{{cookiecutter.project_slug}}/backend/app/app/crud/crud_item.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/crud/crud_item.py
@@ -16,7 +16,6 @@ class CRUDItem(CRUDBase[Item, ItemCreate, ItemUpdate]):
         db_obj = self.model(**obj_in_data, owner_id=owner_id)
         db.add(db_obj)
         db.commit()
-        db.refresh(db_obj)
         return db_obj
 
     def get_multi_by_owner(

--- a/{{cookiecutter.project_slug}}/backend/app/app/crud/crud_user.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/crud/crud_user.py
@@ -21,7 +21,6 @@ class CRUDUser(CRUDBase[User, UserCreate, UserUpdate]):
         )
         db.add(db_obj)
         db.commit()
-        db.refresh(db_obj)
         return db_obj
 
     def update(


### PR DESCRIPTION
When we do db.commit(), this should automatically refresh the db session so there's no need to db.refresh again.