### PR TITLE
change `--exclude=__init__.py` to `--ignore-init-module-imports` in autoflake

### DIFF
--- a/{{cookiecutter.project_slug}}/backend/app/scripts/format.sh
+++ b/{{cookiecutter.project_slug}}/backend/app/scripts/format.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 set -x
 
-autoflake --remove-all-unused-imports --recursive --remove-unused-variables --in-place app --exclude=__init__.py
+autoflake --remove-all-unused-imports --recursive --remove-unused-variables --in-place app --ignore-init-module-imports
 black app
 isort --recursive --apply app


### PR DESCRIPTION
If you use ` --exclude=__init__.py` to avoid removing unused imports, `__init__.py` will not be linted. Use `--ignore-init-module-imports` option.