### PR TITLE
Run each test in there own transaction

### DIFF
--- a/{{cookiecutter.project_slug}}/backend/app/app/tests/conftest.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/tests/conftest.py
@@ -4,16 +4,30 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
+from app.api.deps import get_db
 from app.core.config import settings
-from app.db.session import SessionLocal
+from app.db.session import engine
 from app.main import app
 from app.tests.utils.user import authentication_token_from_email
 from app.tests.utils.utils import get_superuser_token_headers
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture()
 def db() -> Generator:
-    yield SessionLocal()
+    """Run each test in there own transaction"""
+    connection = engine.connect()
+    transaction = connection.begin()
+    session = Session(bind=connection, autocommit=False, autoflush=False)
+
+    app.dependency_overrides[get_db] = lambda: session
+
+    yield session
+
+    app.dependency_overrides.pop(get_db)
+
+    session.close()
+    transaction.rollback()
+    connection.close()
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
This is the first thing I did when I started using the template. It allows me to never have anything really committed to database when running my tests. I don't know how you run your tests but running them each in their own transaction that is then rollbacked and leave no trace whatsoever is to me the cleanest solution when running tests against a database.

I also like the fact that it gives an example of using dependency override.