### PR TITLE
✏️.  Set volume /var/run/docker.sock as read-only

### DIFF
--- a/{{cookiecutter.project_slug}}/docker-compose.yml
+++ b/{{cookiecutter.project_slug}}/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - ${TRAEFIK_PUBLIC_NETWORK?Variable not set}
       - default
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+      - /var/run/docker.sock:/var/run/docker.sock:ro
     command:
       # Enable Docker in Traefik, so that it reads labels from Docker services
       - --providers.docker


### PR DESCRIPTION
This is consistent with the `traefik.yml` in [dockerswarm.rocks](https://dockerswarm.rocks/traefik/#create-the-docker-compose-file)