### PR TITLE
#Issue 207: Can not create inactive user fix

### DIFF
--- a/{{cookiecutter.project_slug}}/backend/app/app/crud/crud_user.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/crud/crud_user.py
@@ -18,6 +18,7 @@ class CRUDUser(CRUDBase[User, UserCreate, UserUpdate]):
             hashed_password=get_password_hash(obj_in.password),
             full_name=obj_in.full_name,
             is_superuser=obj_in.is_superuser,
+            is_active=obj_in.is_active,
         )
         db.add(db_obj)
         db.commit()

--- a/{{cookiecutter.project_slug}}/backend/app/app/tests/crud/test_user.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/tests/crud/test_user.py
@@ -45,10 +45,10 @@ def test_check_if_user_is_active(db: Session) -> None:
 def test_check_if_user_is_active_inactive(db: Session) -> None:
     email = random_email()
     password = random_lower_string()
-    user_in = UserCreate(email=email, password=password, disabled=True)
+    user_in = UserCreate(email=email, password=password, is_active=False)
     user = crud.user.create(db, obj_in=user_in)
     is_active = crud.user.is_active(user)
-    assert is_active
+    assert not is_active
 
 
 def test_check_if_user_is_superuser(db: Session) -> None:


### PR DESCRIPTION
Fix #207 
1. change test_check_if_user_is_active_inactive test function, set correct attribute name, fix wrong assertion
2. update CRUDUser.create, is_active value always referred from obj_in.is_active