### PR TITLE
Update crud_user.py

### DIFF
--- a/{{cookiecutter.project_slug}}/backend/app/app/crud/crud_user.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/crud/crud_user.py
@@ -31,7 +31,7 @@ class CRUDUser(CRUDBase[User, UserCreate, UserUpdate]):
             update_data = obj_in
         else:
             update_data = obj_in.dict(exclude_unset=True)
-        if update_data["password"]:
+        if update_data.get("password"):
             hashed_password = get_password_hash(update_data["password"])
             del update_data["password"]
             update_data["hashed_password"] = hashed_password


### PR DESCRIPTION
Fixes Bug when which crashes the update function, when updating without resending the password. the current approach either the whole function errors when the dict contains no password or it suceeds when there is a password in the dict. I fixed so that it also suceeds when no Password is present. Which enables the edit user profile Page in the frontend to work again .