### PR TITLE
Fix bug: User was not able to update details without providing password

### DIFF
--- a/{{cookiecutter.project_slug}}/backend/app/app/crud/crud_user.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/crud/crud_user.py
@@ -31,7 +31,7 @@ class CRUDUser(CRUDBase[User, UserCreate, UserUpdate]):
             update_data = obj_in
         else:
             update_data = obj_in.dict(exclude_unset=True)
-        if update_data["password"]:
+        if "password" in update_data: # Need to check for password key
             hashed_password = get_password_hash(update_data["password"])
             del update_data["password"]
             update_data["hashed_password"] = hashed_password


### PR DESCRIPTION
Current code was raising error, When user was trying to update name / other details from UI
`backend_1       |   File "./app/crud/crud_user.py", line 34, in update
backend_1       |     if update_data["password"]:
backend_1       | KeyError: 'password'
`