### PR TITLE
Update PIP to make build possible

### DIFF
--- a/{{cookiecutter.project_slug}}/backend/backend.dockerfile
+++ b/{{cookiecutter.project_slug}}/backend/backend.dockerfile
@@ -10,6 +10,8 @@ RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-
 
 # Copy poetry.lock* in case it doesn't exist in the repo
 COPY ./app/pyproject.toml ./app/poetry.lock* /app/
+# Update pip to make sure installation of python packages isn't broken
+RUN pip install -U pip
 
 # Allow installing dev dependencies to run tests
 ARG INSTALL_DEV=false


### PR DESCRIPTION
Without updating PIP, I was getting errors like below, so that I propose to update pip everytime there is a change in requirements(without change in `pyproject.toml` or `poetry.lock` lines 12-14 should be gotten from docker cache).

```
  EnvCommandError

  Command ['/usr/local/bin/python3', '-m', 'pip', 'install', '--no-deps', '/root/.cache/pypoetry/artifacts/4a/30/7c/ed21689451c75210f0aa8a79930950ff7b2ea00060b454a5a04f86d9b2/cryptography-3.4.7-cp36-abi3-manylinux2014_x86_64.whl'] errored with the following return code 1, and output:
  ERROR: cryptography-3.4.7-cp36-abi3-manylinux2014_x86_64.whl is not a supported wheel on this platform.
  WARNING: You are using pip version 19.2.3, however version 21.0.1 is available.
  You should consider upgrading via the 'pip install --upgrade pip' command.


  at /opt/poetry/lib/poetry/utils/env.py:1074 in _run
      1070│                 output = subprocess.check_output(
      1071│                     cmd, stderr=subprocess.STDOUT, **kwargs
      1072│                 )
      1073│         except CalledProcessError as e:
    → 1074│             raise EnvCommandError(e, input=input_)
      1075│
      1076│         return decode(output)
      1077│
      1078│     def execute(self, bin, *args, **kwargs):

  • Installing pyflakes (2.3.1)
  • Installing pytest (5.4.3)
  • Installing python-dateutil (2.8.1)
  • Installing python-editor (1.0.4)
  • Installing pytz (2021.1)
  • Installing regex (2021.4.4)
  • Installing rsa (4.7.2)
  • Installing sqlalchemy (1.4.7)
  • Updating starlette (0.12.9 -> 0.13.2)
  • Installing toml (0.10.2)
  • Updating uvloop (0.13.0 -> 0.15.2)
  • Updating websockets (8.0.2 -> 8.1)

  EnvCommandError

  Command ['/usr/local/bin/python3', '-m', 'pip', 'install', '--no-deps', '/root/.cache/pypoetry/artifacts/5b/86/c7/caf2fd4e0eace88a30e3b2109f1587ce13a19f81611406f179c9dd3754/regex-2021.4.4-cp37-cp37m-manylinux2014_x86_64.whl'] errored with the following return code 1, and output:
  ERROR: regex-2021.4.4-cp37-cp37m-manylinux2014_x86_64.whl is not a supported wheel on this platform.
  WARNING: You are using pip version 19.2.3, however version 21.0.1 is available.
  You should consider upgrading via the 'pip install --upgrade pip' command.


  at /opt/poetry/lib/poetry/utils/env.py:1074 in _run
      1070│                 output = subprocess.check_output(
      1071│                     cmd, stderr=subprocess.STDOUT, **kwargs
      1072│                 )
      1073│         except CalledProcessError as e:
    → 1074│             raise EnvCommandError(e, input=input_)
      1075│
      1076│         return decode(output)
      1077│
      1078│     def execute(self, bin, *args, **kwargs):


  EnvCommandError

  Command ['/usr/local/bin/python3', '-m', 'pip', 'install', '--no-deps', '-U', '/root/.cache/pypoetry/artifacts/6e/17/d9/4f21964986d811c1ad14820f18533bad81c334d063705dba655a35099e/pydantic-1.8.1-cp37-cp37m-manylinux2014_x86_64.whl'] errored with the following return code 1, and output:
  ERROR: pydantic-1.8.1-cp37-cp37m-manylinux2014_x86_64.whl is not a supported wheel on this platform.
  WARNING: You are using pip version 19.2.3, however version 21.0.1 is available.
  You should consider upgrading via the 'pip install --upgrade pip' command.


  at /opt/poetry/lib/poetry/utils/env.py:1074 in _run
      1070│                 output = subprocess.check_output(
      1071│                     cmd, stderr=subprocess.STDOUT, **kwargs
      1072│                 )
      1073│         except CalledProcessError as e:
    → 1074│             raise EnvCommandError(e, input=input_)
      1075│
      1076│         return decode(output)
      1077│
      1078│     def execute(self, bin, *args, **kwargs):


  EnvCommandError

  Command ['/usr/local/bin/python3', '-m', 'pip', 'install', '--no-deps', '/root/.cache/pypoetry/artifacts/b5/9c/b8/ed7f42c0bf7423d3fa128ae8eddf42333774418939968cce6496e4b0a5/SQLAlchemy-1.4.7-cp37-cp37m-manylinux2014_x86_64.whl'] errored with the following return code 1, and output:
  ERROR: SQLAlchemy-1.4.7-cp37-cp37m-manylinux2014_x86_64.whl is not a supported wheel on this platform.
  WARNING: You are using pip version 19.2.3, however version 21.0.1 is available.
  You should consider upgrading via the 'pip install --upgrade pip' command.


  at /opt/poetry/lib/poetry/utils/env.py:1074 in _run
      1070│                 output = subprocess.check_output(
      1071│                     cmd, stderr=subprocess.STDOUT, **kwargs
      1072│                 )
      1073│         except CalledProcessError as e:
    → 1074│             raise EnvCommandError(e, input=input_)
      1075│
      1076│         return decode(output)
      1077│
      1078│     def execute(self, bin, *args, **kwargs):
```