### PR TITLE
fix(backend): user update without password

### DIFF
--- a/{{cookiecutter.project_slug}}/backend/app/app/crud/crud_user.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/crud/crud_user.py
@@ -31,7 +31,7 @@ class CRUDUser(CRUDBase[User, UserCreate, UserUpdate]):
             update_data = obj_in
         else:
             update_data = obj_in.dict(exclude_unset=True)
-        if update_data["password"]:
+        if "password" in update_data:
             hashed_password = get_password_hash(update_data["password"])
             del update_data["password"]
             update_data["hashed_password"] = hashed_password


### PR DESCRIPTION
It solves the error that is generated when updating a user when it receives the json without the password

Example:
{
    "full_name":"New User Name"
}

Backend error:
```
File ".\app\api\api_v1\endpoints\users.py", line 78, in update_user
    user = crud.user.update(db, db_obj=user, obj_in=user_in)
  File ".\app\crud\crud_user.py", line 31, in update
    if update_data["password"]:
KeyError: 'password'
```

![image](https://user-images.githubusercontent.com/57442924/117176167-32dcde00-ad95-11eb-99d5-e3c853db66f6.png)
