### PR TITLE
Fix flower docker image

### DIFF
--- a/{{cookiecutter.project_slug}}/docker-compose.yml
+++ b/{{cookiecutter.project_slug}}/docker-compose.yml
@@ -112,7 +112,7 @@ services:
     # You also have to change the flower command
   
   flower:
-    image: mher/flower
+    image: mher/flower:0.9.7
     networks:
       - ${TRAEFIK_PUBLIC_NETWORK?Variable not set}
       - default


### PR DESCRIPTION
The current image (based on flower 1.0.1) has changed the default cmd,
    meaning the docker compose command fails. Fixing to the previous
    0.9.7 gets things working again.

Fixes https://github.com/tiangolo/full-stack-fastapi-postgresql/issues/398