### PR TITLE
Fix Build and run issues: Polyfill deprecation and flower image start failure

### DIFF
--- a/{{cookiecutter.project_slug}}/docker-compose.yml
+++ b/{{cookiecutter.project_slug}}/docker-compose.yml
@@ -112,7 +112,7 @@ services:
     # You also have to change the flower command
   
   flower:
-    image: mher/flower
+    image: mher/flower:0.9.4
     networks:
       - ${TRAEFIK_PUBLIC_NETWORK?Variable not set}
       - default

--- a/{{cookiecutter.project_slug}}/frontend/src/main.ts
+++ b/{{cookiecutter.project_slug}}/frontend/src/main.ts
@@ -1,4 +1,5 @@
-import '@babel/polyfill';
+import "core-js/stable";
+import "regenerator-runtime/runtime";
 // Import Component hooks before component definitions
 import './component-hooks';
 import Vue from 'vue';


### PR DESCRIPTION
From the official polypill documentation https://babeljs.io/docs/en/babel-polyfill. This will fail out at build time
```
import "core-js/stable";
import "regenerator-runtime/runtime";
```

Also fix failing flower run in docker compose up with version pin