### PR TITLE
Update poetry url to new location

### DIFF
--- a/{{cookiecutter.project_slug}}/backend/backend.dockerfile
+++ b/{{cookiecutter.project_slug}}/backend/backend.dockerfile
@@ -3,7 +3,7 @@ FROM tiangolo/uvicorn-gunicorn-fastapi:python3.7
 WORKDIR /app/
 
 # Install Poetry
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | POETRY_HOME=/opt/poetry python && \
+RUN curl -sSL https://install.python-poetry.org | POETRY_HOME=/opt/poetry python && \
     cd /usr/local/bin && \
     ln -s /opt/poetry/bin/poetry && \
     poetry config virtualenvs.create false

--- a/{{cookiecutter.project_slug}}/backend/celeryworker.dockerfile
+++ b/{{cookiecutter.project_slug}}/backend/celeryworker.dockerfile
@@ -3,7 +3,7 @@ FROM python:3.7
 WORKDIR /app/
 
 # Install Poetry
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | POETRY_HOME=/opt/poetry python && \
+RUN curl -sSL https://install.python-poetry.org | POETRY_HOME=/opt/poetry python && \
     cd /usr/local/bin && \
     ln -s /opt/poetry/bin/poetry && \
     poetry config virtualenvs.create false


### PR DESCRIPTION
This PR updates the poetry installer URL for the backend & celery container.
It's currently using a poetry installer URL that is deprecated, and scheduled for removal from the Poetry repository on or after January 1, 2023.

See https://github.com/python-poetry/poetry/issues/6377 for details.