### PR TITLE
replace get-poerty.py script with 'install.python-poetry.org'

### DIFF
--- a/{{cookiecutter.project_slug}}/backend/backend.dockerfile
+++ b/{{cookiecutter.project_slug}}/backend/backend.dockerfile
@@ -3,7 +3,7 @@ FROM tiangolo/uvicorn-gunicorn-fastapi:python3.7
 WORKDIR /app/
 
 # Install Poetry
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | POETRY_HOME=/opt/poetry python && \
+RUN curl -sSL https://install.python-poetry.org| POETRY_HOME=/opt/poetry python && \
     cd /usr/local/bin && \
     ln -s /opt/poetry/bin/poetry && \
     poetry config virtualenvs.create false

--- a/{{cookiecutter.project_slug}}/backend/celeryworker.dockerfile
+++ b/{{cookiecutter.project_slug}}/backend/celeryworker.dockerfile
@@ -3,7 +3,7 @@ FROM python:3.7
 WORKDIR /app/
 
 # Install Poetry
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | POETRY_HOME=/opt/poetry python && \
+RUN curl -sSL https://install.python-poetry.org| POETRY_HOME=/opt/poetry python && \
     cd /usr/local/bin && \
     ln -s /opt/poetry/bin/poetry && \
     poetry config virtualenvs.create false


### PR DESCRIPTION
The get-poetry.py installer has been deprecated and removed.  
need to update to : 
`curl -sSL https://install.python-poetry.org | python3 -`

refer: 
https://python-poetry.org/docs/#installing-with-the-official-installer

