### PR TITLE
orm_mode should be from_attributes

### DIFF
--- a/{{cookiecutter.project_slug}}/backend/app/app/schemas/item.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/schemas/item.py
@@ -26,7 +26,7 @@ class ItemInDBBase(ItemBase):
     owner_id: int
 
     class Config:
-        orm_mode = True
+        from_attributes = True
 
 
 # Properties to return to client

--- a/{{cookiecutter.project_slug}}/backend/app/app/schemas/user.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/schemas/user.py
@@ -26,7 +26,7 @@ class UserInDBBase(UserBase):
     id: Optional[int] = None
 
     class Config:
-        orm_mode = True
+        from_attributes = True
 
 
 # Additional properties to return via API


### PR DESCRIPTION
`orm_mode` should be `from_attributes` because it's gives 

> UserWarning: Valid config keys have changed in V2: * 'orm_mode' has been renamed to 'from_attributes'

warning.