### PR TITLE
Update generate_cookiecutter_config.py to format YAML output correctly

### DIFF
--- a/scripts/generate_cookiecutter_config.py
+++ b/scripts/generate_cookiecutter_config.py
@@ -1,20 +1,30 @@
 import json
+import yaml
 from collections import OrderedDict
-import oyaml as yaml
 from pathlib import Path
-cookie_path = Path('./cookiecutter.json')
-out_path = Path('./{{cookiecutter.project_slug}}/cookiecutter-config-file.yml')
+
+
+def dict_representer(dumper, data):
+    return dumper.represent_dict(data.items())
+
+
+yaml.add_representer(OrderedDict, dict_representer)
+
+cookie_path = Path("./cookiecutter.json")
+out_path = Path("./cookiecutter-config-file.yml")
 
 with open(cookie_path) as f:
     cookie_config = json.load(f)
 config_out = OrderedDict()
 
 for key, value in cookie_config.items():
-    if key.startswith('_'):
+    if key.startswith("_"):
         config_out[key] = value
     else:
-        config_out[key] = '{{ cookiecutter.' + key + ' }}'
-config_out['_template'] = './'
+        config_out[key] = "{{ cookiecutter." + key + " }}"
+config_out["_template"] = "./"
 
-with open(out_path, 'w') as out_f:
-    out_f.write(yaml.dump({'default_context': config_out}, line_break=None, width=200))
+with open(out_path, "w") as out_f:
+    out_f.write(
+        yaml.dump({"default_context": config_out}, default_flow_style=False, width=1000)
+    )


### PR DESCRIPTION
will create` full-stack-fastapi-postgresql/cookiecutter-config-file.yml`

with content:

```
default_context:
  project_name: '{{ cookiecutter.project_name }}'
  project_slug: '{{ cookiecutter.project_slug }}'
  domain_main: '{{ cookiecutter.domain_main }}'
  domain_staging: '{{ cookiecutter.domain_staging }}'
  docker_swarm_stack_name_main: '{{ cookiecutter.docker_swarm_stack_name_main }}'
  docker_swarm_stack_name_staging: '{{ cookiecutter.docker_swarm_stack_name_staging }}'
  secret_key: '{{ cookiecutter.secret_key }}'
  first_superuser: '{{ cookiecutter.first_superuser }}'
  first_superuser_password: '{{ cookiecutter.first_superuser_password }}'
  backend_cors_origins: '{{ cookiecutter.backend_cors_origins }}'
  smtp_port: '{{ cookiecutter.smtp_port }}'
  smtp_host: '{{ cookiecutter.smtp_host }}'
  smtp_user: '{{ cookiecutter.smtp_user }}'
  smtp_password: '{{ cookiecutter.smtp_password }}'
  smtp_emails_from_email: '{{ cookiecutter.smtp_emails_from_email }}'
  postgres_password: '{{ cookiecutter.postgres_password }}'
  pgadmin_default_user: '{{ cookiecutter.pgadmin_default_user }}'
  pgadmin_default_user_password: '{{ cookiecutter.pgadmin_default_user_password }}'
  traefik_constraint_tag: '{{ cookiecutter.traefik_constraint_tag }}'
  traefik_constraint_tag_staging: '{{ cookiecutter.traefik_constraint_tag_staging }}'
  traefik_public_constraint_tag: '{{ cookiecutter.traefik_public_constraint_tag }}'
  flower_auth: '{{ cookiecutter.flower_auth }}'
  sentry_dsn: '{{ cookiecutter.sentry_dsn }}'
  docker_image_prefix: '{{ cookiecutter.docker_image_prefix }}'
  docker_image_backend: '{{ cookiecutter.docker_image_backend }}'
  docker_image_celeryworker: '{{ cookiecutter.docker_image_celeryworker }}'
  docker_image_frontend: '{{ cookiecutter.docker_image_frontend }}'
  _copy_without_render:
  - frontend/src/**/*.html
  - frontend/src/**/*.vue
  - frontend/node_modules/*
  - backend/app/app/email-templates/**
  _template: ./

```