### PR TITLE
🔧 Add `.gitattributes` file to ensure LF endings for `.sh` files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+*.sh text eol=lf


### PR DESCRIPTION
Added .gitattributes to ensure LF endings in scripts files despite operative system and repository configuration